### PR TITLE
feat: Implement simple Todo API with in-memory storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "uuid": "^10.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -38,6 +39,7 @@
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.7",
     "@types/supertest": "^6.0.2",
+    "@types/uuid": "^10.0.0",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.2",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { TodoModule } from './todo/todo.module';
 
 @Module({
-  imports: [],
+  imports: [TodoModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/todo/dto/create-todo.dto.ts
+++ b/src/todo/dto/create-todo.dto.ts
@@ -1,0 +1,18 @@
+// import { IsString, IsNotEmpty, IsOptional, IsBoolean } from 'class-validator'; // Cannot use due to npm install issues
+
+export class CreateTodoDto {
+  // @IsString()
+  // @IsNotEmpty()
+  title: string;
+
+  // @IsString()
+  // @IsOptional()
+  description?: string;
+
+  // Note: 'completed' status is typically not part of CreateTodoDto,
+  // as it's usually set to false by default on creation.
+  // If it were allowed:
+  // @IsBoolean()
+  // @IsOptional()
+  // completed?: boolean;
+}

--- a/src/todo/dto/index.ts
+++ b/src/todo/dto/index.ts
@@ -1,0 +1,2 @@
+export * from './create-todo.dto';
+export * from './update-todo.dto';

--- a/src/todo/dto/update-todo.dto.ts
+++ b/src/todo/dto/update-todo.dto.ts
@@ -1,0 +1,15 @@
+// import { IsString, IsOptional, IsBoolean } from 'class-validator'; // Cannot use due to npm install issues
+
+export class UpdateTodoDto {
+  // @IsString()
+  // @IsOptional()
+  title?: string;
+
+  // @IsString()
+  // @IsOptional()
+  description?: string;
+
+  // @IsBoolean()
+  // @IsOptional()
+  completed?: boolean;
+}

--- a/src/todo/interfaces/todo.interface.ts
+++ b/src/todo/interfaces/todo.interface.ts
@@ -1,0 +1,6 @@
+export interface Todo {
+  id: string;
+  title: string;
+  description?: string; // Optional property
+  completed: boolean;
+}

--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -1,0 +1,59 @@
+import { Controller, Get, Post, Body, Param, Delete, Patch, NotFoundException, HttpCode, HttpStatus } from '@nestjs/common';
+import { TodoService } from './todo.service';
+import { CreateTodoDto, UpdateTodoDto } from './dto'; // Using index.ts for DTO imports
+import { Todo } from './interfaces/todo.interface';
+
+@Controller('todos')
+export class TodoController {
+  constructor(private readonly todoService: TodoService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  create(@Body() createTodoDto: CreateTodoDto): Todo {
+    // The service's create method expects Omit<Todo, 'id' | 'completed'>
+    // CreateTodoDto matches this structure (title, description?)
+    return this.todoService.create(createTodoDto);
+  }
+
+  @Get()
+  findAll(): Todo[] {
+    return this.todoService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string): Todo {
+    try {
+      return this.todoService.findOne(id);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw new NotFoundException(error.message);
+      }
+      throw error; // Re-throw other errors
+    }
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateTodoDto: UpdateTodoDto): Todo {
+    try {
+      return this.todoService.update(id, updateTodoDto);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw new NotFoundException(error.message);
+      }
+      throw error; // Re-throw other errors
+    }
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.OK) // Or HttpStatus.NO_CONTENT if preferred, then return void
+  remove(@Param('id') id: string): { deleted: boolean; id: string } {
+    try {
+      return this.todoService.remove(id);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw new NotFoundException(error.message);
+      }
+      throw error; // Re-throw other errors
+    }
+  }
+}

--- a/src/todo/todo.module.ts
+++ b/src/todo/todo.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TodoController } from './todo.controller';
+import { TodoService } from './todo.service';
+
+@Module({
+  controllers: [TodoController],
+  providers: [TodoService],
+})
+export class TodoModule {}

--- a/src/todo/todo.service.spec.ts
+++ b/src/todo/todo.service.spec.ts
@@ -1,0 +1,100 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TodoService } from './todo.service';
+import { Todo } from './interfaces/todo.interface';
+import { NotFoundException } from '@nestjs/common';
+
+describe('TodoService', () => {
+  let service: TodoService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TodoService],
+    }).compile();
+
+    service = module.get<TodoService>(TodoService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a new todo', () => {
+      const todoData = { title: 'Test Todo', description: 'Test Description' };
+      const todo = service.create(todoData);
+      expect(todo).toHaveProperty('id');
+      expect(todo.title).toBe(todoData.title);
+      expect(todo.description).toBe(todoData.description);
+      expect(todo.completed).toBe(false);
+      expect(service.findAll()).toHaveLength(1);
+      expect(service.findAll()[0]).toEqual(todo);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return an array of todos', () => {
+      expect(service.findAll()).toEqual([]);
+      service.create({ title: 'Todo 1' });
+      service.create({ title: 'Todo 2' });
+      expect(service.findAll()).toHaveLength(2);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a single todo if found', () => {
+      const todoData = { title: 'Test Find' };
+      const createdTodo = service.create(todoData);
+      const foundTodo = service.findOne(createdTodo.id);
+      expect(foundTodo).toEqual(createdTodo);
+    });
+
+    it('should throw NotFoundException if todo not found', () => {
+      expect(() => service.findOne('nonexistent-id')).toThrow(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('should update an existing todo', () => {
+      const createdTodo = service.create({ title: 'Initial Title' });
+      const updates = { title: 'Updated Title', completed: true, description: 'New Desc' };
+      const updatedTodo = service.update(createdTodo.id, updates);
+
+      expect(updatedTodo.id).toBe(createdTodo.id);
+      expect(updatedTodo.title).toBe(updates.title);
+      expect(updatedTodo.completed).toBe(updates.completed);
+      expect(updatedTodo.description).toBe(updates.description);
+    });
+
+    it('should partially update an existing todo', () => {
+      const createdTodo = service.create({ title: 'Partial Update', description: 'Keep this' });
+      const updates = { completed: true };
+      const updatedTodo = service.update(createdTodo.id, updates);
+
+      expect(updatedTodo.id).toBe(createdTodo.id);
+      expect(updatedTodo.title).toBe('Partial Update');
+      expect(updatedTodo.description).toBe('Keep this');
+      expect(updatedTodo.completed).toBe(true);
+    });
+
+    it('should throw NotFoundException if todo to update is not found', () => {
+      expect(() => service.update('nonexistent-id', { title: 'Update Fail' })).toThrow(NotFoundException);
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove an existing todo', () => {
+      const createdTodo1 = service.create({ title: 'To Delete' });
+      const createdTodo2 = service.create({ title: 'To Keep' });
+      expect(service.findAll()).toHaveLength(2);
+
+      const result = service.remove(createdTodo1.id);
+      expect(result).toEqual({ deleted: true, id: createdTodo1.id });
+      expect(service.findAll()).toHaveLength(1);
+      expect(service.findAll()[0]).toEqual(createdTodo2);
+    });
+
+    it('should throw NotFoundException if todo to remove is not found', () => {
+      expect(() => service.remove('nonexistent-id')).toThrow(NotFoundException);
+    });
+  });
+});

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Todo } from './interfaces/todo.interface';
+// DTOs will be used in the next step, for now using partial Todo for create/update
+// import { CreateTodoDto } from './dto/create-todo.dto';
+// import { UpdateTodoDto } from './dto/update-todo.dto';
+
+@Injectable()
+export class TodoService {
+  private todos: Todo[] = [];
+  private currentId: number = 1; // Simple ID generator
+
+  create(todoData: Omit<Todo, 'id' | 'completed'>): Todo {
+    const newTodo: Todo = {
+      id: (this.currentId++).toString(),
+      ...todoData,
+      completed: false, // Default to not completed
+    };
+    this.todos.push(newTodo);
+    return newTodo;
+  }
+
+  findAll(): Todo[] {
+    return this.todos;
+  }
+
+  findOne(id: string): Todo {
+    const todo = this.todos.find(t => t.id === id);
+    if (!todo) {
+      throw new NotFoundException(`Todo with ID "${id}" not found`);
+    }
+    return todo;
+  }
+
+  update(id: string, todoUpdateData: Partial<Omit<Todo, 'id'>>): Todo {
+    const todo = this.findOne(id); // Leverages the not found exception
+    const todoIndex = this.todos.findIndex(t => t.id === id);
+
+    // Create an updated version of the todo item
+    const updatedTodo = { ...todo, ...todoUpdateData };
+
+    // Update the item in the array
+    this.todos[todoIndex] = updatedTodo;
+    return updatedTodo;
+  }
+
+  remove(id: string): { deleted: boolean; id: string } {
+    const todoIndex = this.todos.findIndex(t => t.id === id);
+    if (todoIndex === -1) {
+      throw new NotFoundException(`Todo with ID "${id}" not found`);
+    }
+    this.todos.splice(todoIndex, 1);
+    return { deleted: true, id };
+  }
+}


### PR DESCRIPTION
- Create TodoModule, TodoService, and TodoController.
- Define Todo interface and DTOs (CreateTodoDto, UpdateTodoDto).
- Implement CRUD operations for Todos using an in-memory array.
- Add basic error handling for not found resources.
- Write unit tests for TodoService (unable to run due to environment issues).

Note: Due to environment errors preventing 'npm install', 'uuid' could not be used (switched to numeric IDs) and 'class-validator' decorators were omitted.